### PR TITLE
Fix usage of RegSetValueEx

### DIFF
--- a/plugin/Cookie/CookieManager.cpp
+++ b/plugin/Cookie/CookieManager.cpp
@@ -17,7 +17,9 @@ namespace Cookie
 		HKEY key;
 		if(ERROR_SUCCESS == RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders"), 0, KEY_SET_VALUE, &key))
 		{
-			RegSetValueEx(key, csRegName, 0, REG_EXPAND_SZ, (LPBYTE)csCookie.GetBuffer(), 1024);
+			LPBYTE buffer = (LPBYTE)csCookie.GetBuffer();
+			DWORD length = (csCookie.GetLength() + 1) * sizeof(TCHAR);
+			RegSetValueEx(key, csRegName, 0, REG_EXPAND_SZ, buffer, length);
 			csCookie.ReleaseBuffer();
 			RegCloseKey(key);
 		}


### PR DESCRIPTION
According to http://msdn.microsoft.com/en-us/library/windows/desktop/ms724923%28v=vs.85%29.aspx
The last param cbData should be the size, in bytes, of the information pointed to by lpData, and should include the null chars.
