### PR TITLE
Get rid of nsIPrefBranch2

### DIFF
--- a/extension/components/Initializer.js
+++ b/extension/components/Initializer.js
@@ -34,7 +34,7 @@ Initializer.prototype = {
   observe: function(subject, topic, data)
   {
     let observerService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
-    let prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).QueryInterface(Ci.nsIPrefBranch2);
+    let prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).QueryInterface(Ci.nsIPrefBranch);
 
     switch (topic)
     {

--- a/extension/modules/ABPObserver.jsm
+++ b/extension/modules/ABPObserver.jsm
@@ -313,7 +313,6 @@ let ABPObserver = {
     this._abpBranch = Services.prefs.getBranch(adblocker.prefsBranch);
     if (this._abpBranch)
     {
-      this._abpBranch.QueryInterface(Ci.nsIPrefBranch2);
       this._abpBranch.addObserver("", ABPObserverPrivate, false);
     }
 

--- a/extension/modules/GesturePrefObserver.jsm
+++ b/extension/modules/GesturePrefObserver.jsm
@@ -107,7 +107,6 @@ let GesturePrefObserver = {
     try
     {
       let self = this;
-      this.gestureBranch.QueryInterface(Ci.nsIPrefBranch2);
       this.gestureBranchObserver =
       {
         /**

--- a/extension/modules/Prefs.jsm
+++ b/extension/modules/Prefs.jsm
@@ -220,8 +220,7 @@ function registerObservers()
   // Observe preferences changes
   try
   {
-    branch.QueryInterface(Ci.nsIPrefBranch2)
-          .addObserver("", PrefsPrivate, true);
+    branch.addObserver("", PrefsPrivate, true);
   }
   catch (e)
   {

--- a/extension/modules/UtilsPluginManager.jsm
+++ b/extension/modules/UtilsPluginManager.jsm
@@ -35,8 +35,7 @@ Cu.import(baseURL.spec + "Utils.jsm");
 Cu.import(baseURL.spec + "IECookieManager.jsm");
 Cu.import(baseURL.spec + "Prefs.jsm");
 
-let prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).QueryInterface(Ci.nsIPrefBranch2);
-let dntBranch = prefs.getBranch("privacy.donottrackheader.").QueryInterface(Ci.nsIPrefBranch2);
+let dntBranch = Services.prefs.getBranch("privacy.donottrackheader.");
 
 let UtilsPluginManager = {
   /**


### PR DESCRIPTION
`nsIPrefBranch2` was merged into `nsIPrefBranch` (https://bugzilla.mozilla.org/show_bug.cgi?id=718255), so we can get rid of it now.