### PR TITLE
Add an option to use the Firefox status bar, if available

### DIFF
--- a/extension/chrome/content/options2.js
+++ b/extension/chrome/content/options2.js
@@ -103,6 +103,7 @@ Options.apply = function(quiet)
   Prefs.ieLabel = E("ieLabel").value;
   Prefs.showTooltipText = E("showTooltipText").checked;
   Prefs.showStatusText = E("showStatusText").checked;
+  Prefs.useNativeStatusBar = E("useNativeStatusBar").checked;
   Prefs.showContextMenuItems = E("showContextMenuItems").checked;
   
   // Integration
@@ -419,6 +420,11 @@ Options.updateAutoSwitchElements = function()
   });
 };
 
+Options.updateNativeStatusBarCheckbox = function()
+{
+  E("useNativeStatusBar").hidden = !E("showStatusText").checked;
+}
+
 Options._getGroupValue = function(value, allowedValues, defValue)
 {
   if (allowedValues.indexOf(value) !== -1)
@@ -448,6 +454,7 @@ Options.initDialog = function(restore)
   E("ieLabel").value = Prefs.ieLabel; E("ieLabel").placeholder = Utils.getString("fireie.urlbar.switch.label.ie");
   E("showTooltipText").checked = Prefs.showTooltipText;
   E("showStatusText").checked = Prefs.showStatusText;
+  E("useNativeStatusBar").checked = Prefs.useNativeStatusBar;
   E("showContextMenuItems").checked = Prefs.showContextMenuItems;
   // hide "showStatusText" if we don't handle status messages ourselves
   let ifHide = !AppIntegration.shouldShowStatusOurselves();
@@ -484,6 +491,7 @@ Options.initDialog = function(restore)
   Options.handleShortcutEnabled();
   Options.updateCustomLabelsUI();
   Options.updateABPStatus();
+  Options.updateNativeStatusBarCheckbox();
   Options.updateApplyButton(false);
 };
 
@@ -555,6 +563,8 @@ Options.init = function()
   E("iconDisplay").addEventListener("command", Options.updateCustomLabelsUI, false);
   E("showUrlBarButtonOnlyForIE").addEventListener("command", Options.updateCustomLabelsUI, false);
   E("iemode-menulist").addEventListener("command", Options.updateIECompatDescription, false);
+  
+  E("showStatusText").addEventListener("command", Options.updateNativeStatusBarCheckbox, false);
 
   ABPObserver.addListener(Options.updateABPStatus);
   window.addEventListener("unload", function()

--- a/extension/chrome/content/options2.xul
+++ b/extension/chrome/content/options2.xul
@@ -200,6 +200,7 @@
         <caption label="&fireie.options.ui.statusBarCaption;" />
         <vbox>
           <checkbox label="&fireie.options.ui.showStatusText;" id="showStatusText" />
+          <checkbox label="&fireie.options.ui.useNativeStatusBar;" id="useNativeStatusBar" />
         </vbox>
       </groupbox>
       <groupbox id="contextMenuGroup">

--- a/extension/chrome/locale/en/fireie.dtd
+++ b/extension/chrome/locale/en/fireie.dtd
@@ -41,6 +41,7 @@
 <!ENTITY fireie.options.ui.showTooltipText "Show engine status when hovering URL bar button">
 <!ENTITY fireie.options.ui.statusBarCaption "Floating Status Bar">
 <!ENTITY fireie.options.ui.showStatusText "Show IE engine's status in the floating status bar">
+<!ENTITY fireie.options.ui.useNativeStatusBar "Use the existing Firefox status bar (if any)">
 <!ENTITY fireie.options.ui.faviconCaption "Tab Icon">
 <!ENTITY fireie.options.ui.faviconSite "Use website's favicon">
 <!ENTITY fireie.options.ui.faviconIE "Use IE engine's icon">

--- a/extension/chrome/locale/fr/fireie.dtd
+++ b/extension/chrome/locale/fr/fireie.dtd
@@ -41,6 +41,7 @@
 <!ENTITY fireie.options.ui.showTooltipText "Afficher le statut du moteur de rendu lorsque le curseur est sur le bouton de barre d'adresse">
 <!ENTITY fireie.options.ui.statusBarCaption "Barre de statut flottante">
 <!ENTITY fireie.options.ui.showStatusText "Afficher le statut du moteur IE dans la barre de statut flottante">
+<!ENTITY fireie.options.ui.useNativeStatusBar "Utiliser le statut du moteur Firefox (en supposant qu'il existe)">
 <!ENTITY fireie.options.ui.faviconCaption "Icône d'onglet">
 <!ENTITY fireie.options.ui.faviconSite "Utiliser le favicon du site Web">
 <!ENTITY fireie.options.ui.faviconIE "Utiliser l'icône du moteur IE">

--- a/extension/chrome/locale/nl/fireie.dtd
+++ b/extension/chrome/locale/nl/fireie.dtd
@@ -38,6 +38,7 @@
 <!ENTITY fireie.options.ui.showTooltipText "Enginestatus weergeven bij aanwijzen adresbalkknop">
 <!ENTITY fireie.options.ui.statusBarCaption "Drijvende statusbalk">
 <!ENTITY fireie.options.ui.showStatusText "Status IE-engine weergeven in drijvende statusbalk">
+<!ENTITY fireie.options.ui.useNativeStatusBar "Use the existing Firefox status bar (if any)">
 <!ENTITY fireie.options.ui.faviconCaption "Tabbladpictogram">
 <!ENTITY fireie.options.ui.faviconSite "Favicon van website gebruiken">
 <!ENTITY fireie.options.ui.faviconIE "Pictogram IE-engine gebruiken">

--- a/extension/chrome/locale/pl/fireie.dtd
+++ b/extension/chrome/locale/pl/fireie.dtd
@@ -38,6 +38,7 @@
 <!ENTITY fireie.options.ui.showTooltipText "Pokazuj status silnika przy wskazywaniu paska adresu">
 <!ENTITY fireie.options.ui.statusBarCaption "Pasek dodatków">
 <!ENTITY fireie.options.ui.showStatusText "Pokaż status silnika IE na pasku dodatków (stanu)">
+<!ENTITY fireie.options.ui.useNativeStatusBar "Use the existing Firefox status bar (if any)">
 <!ENTITY fireie.options.ui.faviconCaption "Ikona karty">
 <!ENTITY fireie.options.ui.faviconSite "Używaj favikony strony">
 <!ENTITY fireie.options.ui.faviconIE "Używaj ikony silnika IE">

--- a/extension/chrome/locale/ru-RU/fireie.dtd
+++ b/extension/chrome/locale/ru-RU/fireie.dtd
@@ -38,6 +38,7 @@
 <!ENTITY fireie.options.ui.showTooltipText "Показывать статус движка при наведении курсора на кнопку">
 <!ENTITY fireie.options.ui.statusBarCaption "Всплывающая строка статуса">
 <!ENTITY fireie.options.ui.showStatusText "Показывать статус во всплывающей строке статуса при активном IE движке">
+<!ENTITY fireie.options.ui.useNativeStatusBar "Use the existing Firefox status bar (if any)">
 <!ENTITY fireie.options.ui.faviconCaption "Tab Icon">
 <!ENTITY fireie.options.ui.faviconSite "Use website's favicon">
 <!ENTITY fireie.options.ui.faviconIE "Use IE engine's icon">

--- a/extension/chrome/locale/zh-CN/fireie.dtd
+++ b/extension/chrome/locale/zh-CN/fireie.dtd
@@ -41,6 +41,7 @@
 <!ENTITY fireie.options.ui.showTooltipText "鼠标悬停时显示引擎状态信息">
 <!ENTITY fireie.options.ui.statusBarCaption "浮动状态栏">
 <!ENTITY fireie.options.ui.showStatusText "在浮动状态栏中显示 IE 引擎的状态消息">
+<!ENTITY fireie.options.ui.useNativeStatusBar "Use the existing Firefox status bar (if any)">
 <!ENTITY fireie.options.ui.faviconCaption "标签页图标">
 <!ENTITY fireie.options.ui.faviconSite "使用网站图标">
 <!ENTITY fireie.options.ui.faviconIE "使用 IE 引擎图标">

--- a/extension/chrome/locale/zh-TW/fireie.dtd
+++ b/extension/chrome/locale/zh-TW/fireie.dtd
@@ -38,6 +38,7 @@
 <!ENTITY fireie.options.ui.showTooltipText "滑鼠停留時顯示引擎狀態資訊">
 <!ENTITY fireie.options.ui.statusBarCaption "浮動狀態列">
 <!ENTITY fireie.options.ui.showStatusText "在浮動狀態列中顯示 IE 引擎的狀態訊息">
+<!ENTITY fireie.options.ui.useNativeStatusBar "Use the existing Firefox status bar (if any)">
 <!ENTITY fireie.options.ui.faviconCaption "分頁圖示">
 <!ENTITY fireie.options.ui.faviconSite "使用網站圖示">
 <!ENTITY fireie.options.ui.faviconIE "使用 IE 引擎圖示">

--- a/extension/defaults/preferences/fireie.js
+++ b/extension/defaults/preferences/fireie.js
@@ -35,6 +35,7 @@ pref("extensions.fireie.showUrlBarLabel", true);
 pref("extensions.fireie.hideUrlBarButton", false);
 pref("extensions.fireie.showTooltipText", true);
 pref("extensions.fireie.showStatusText", true);
+pref("extensions.fireie.useNativeStatusBar", false);
 pref("extensions.fireie.showSiteFavicon", true);
 pref("extensions.fireie.fxLabel", "");
 pref("extensions.fireie.ieLabel", "");

--- a/extension/modules/AppIntegration.jsm
+++ b/extension/modules/AppIntegration.jsm
@@ -1415,14 +1415,21 @@ WindowWrapper.prototype = {
       
       if (Prefs.showStatusText)
       {
-        let event = this.window.gBrowser.contentDocument.createEvent("CustomEvent");
-        event.initCustomEvent("SetStatusText", false, false, {
-          "statusText": pluginObject.StatusText,
-          "preventFlash": AppIntegration.shouldPreventStatusFlash()
-        });
-        statusBar.dispatchEvent(event);
+        if (Prefs.useNativeStatusBar)
+        {
+          this.window.gBrowser.contentWindow.status = pluginObject.StatusText;
+        }
+        else
+        {
+          let event = this.window.gBrowser.contentDocument.createEvent("CustomEvent");
+          event.initCustomEvent("SetStatusText", false, false, {
+            "statusText": pluginObject.StatusText,
+            "preventFlash": AppIntegration.shouldPreventStatusFlash()
+          });
+          statusBar.dispatchEvent(event);
+        }
       }
-      else if (!statusBar.hidden && !Prefs.showStatusText)
+      else if (!statusBar.hidden)
       {
         // event to notify content doc to hide status text
         let event = this.window.gBrowser.contentDocument.createEvent("CustomEvent");


### PR DESCRIPTION
Works with the Status-4-Evar Firefox extension as well as SeaMonkey's status bar (although SeaMonkey would need other changes; you can see those on the other branches of my fork.) The option is off by default.

The field in the options window is "Use the existing Firefox status bar (if any)". I didn't try to translate it for any languages besides French, You might want to change & clarify the text anyway.