### PR TITLE
Use contentDocument.nodePrincipal instead of contentPrincipal

### DIFF
--- a/extension/modules/AppIntegration.jsm
+++ b/extension/modules/AppIntegration.jsm
@@ -2331,7 +2331,7 @@ WindowWrapper.prototype = {
     try
     {
       this.window.urlSecurityCheck(url,
-        this.window.gBrowser.contentPrincipal,
+        this.window.gBrowser.contentDocument.nodePrincipal,
         Ci.nsIScriptSecurityManager.DISALLOW_INHERIT_PRINCIPAL);
       return true;
     }


### PR DESCRIPTION
SeaMonkey does not have contentPrincipal in the browser object, but according to this post http://project_owners.mozdev.narkive.com/y4vAlMg0/firefox-seamonkey-api-parity it's shorthand for contentDocument.nodePrincipal.
Can you make sure this still works in Firefox? Seems OK on SeaMonkey 2.42 and Pale Moon.